### PR TITLE
Improve Reason parsing for Grafana alerts

### DIFF
--- a/lambdas/collector/__tests__/transformers/grafana.test.ts
+++ b/lambdas/collector/__tests__/transformers/grafana.test.ts
@@ -397,4 +397,93 @@ describe("GrafanaTransformer", () => {
       });
     });
   });
+
+  describe("parseValueString", () => {
+    it("should parse valueString with no labels", () => {
+      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=queue_size_threshold labels={} value=1 ]";
+
+      // Access private method through type assertion
+      const result = (transformer as any).parseValueString(valueString);
+
+      expect(result).toBe("max_queue_size=104, queue_size_threshold=1");
+    });
+
+    it("should parse valueString with labels and group by labels", () => {
+      const valueString = "[ var=cpu_usage labels={instance=server1,env=prod} value=85 ], [ var=memory_usage labels={instance=server1,env=prod} value=70 ], [ var=disk_usage labels={instance=server2,env=dev} value=45 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      // Should group by labels
+      expect(result).toContain("[instance=server1,env=prod] cpu_usage=85, memory_usage=70");
+      expect(result).toContain("[instance=server2,env=dev] disk_usage=45");
+    });
+
+    it("should handle mixed scenarios with some items having labels and others not", () => {
+      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=cpu_usage labels={instance=server1} value=85 ], [ var=disk_usage labels={instance=server1} value=70 ], [ var=threshold_breached labels={} value=1 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      // No labels group
+      expect(result).toContain("max_queue_size=104, threshold_breached=1");
+      // Labeled group
+      expect(result).toContain("[instance=server1] cpu_usage=85, disk_usage=70");
+    });
+
+    it("should handle the example from the requirements", () => {
+      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=max_queue_time_mins labels={} value=7 ], [ var=queue_size_threshold labels={} value=1 ], [ var=queue_time_threshold labels={} value=0 ], [ var=threshold_breached labels={} value=1 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      expect(result).toBe("max_queue_size=104, max_queue_time_mins=7, queue_size_threshold=1, queue_time_threshold=0, threshold_breached=1");
+    });
+
+    it("should handle empty or invalid valueString", () => {
+      expect((transformer as any).parseValueString("")).toBe("");
+      expect((transformer as any).parseValueString(null)).toBe("");
+      expect((transformer as any).parseValueString(undefined)).toBe("");
+      expect((transformer as any).parseValueString("invalid format")).toBe("invalid format");
+    });
+
+    it("should handle valueString with complex label values", () => {
+      const valueString = "[ var=response_time labels={service=api,version=v1.2.3,region=us-east-1} value=250 ], [ var=error_rate labels={service=api,version=v1.2.3,region=us-east-1} value=0.5 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      expect(result).toBe("[service=api,version=v1.2.3,region=us-east-1] response_time=250, error_rate=0.5");
+    });
+
+    it("should preserve original string if parsing fails", () => {
+      const malformedString = "malformed [ var=test";
+
+      const result = (transformer as any).parseValueString(malformedString);
+
+      expect(result).toBe(malformedString);
+    });
+
+    it("should handle single entry valueString", () => {
+      const valueString = "[ var=single_metric labels={env=prod} value=42 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      expect(result).toBe("[env=prod] single_metric=42");
+    });
+
+    it("should handle valueString without labels parameter (future-proofing)", () => {
+      const valueString = "[ var=max_queue_size value=104 ], [ var=queue_size_threshold value=1 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      expect(result).toBe("max_queue_size=104, queue_size_threshold=1");
+    });
+
+    it("should handle mixed format with some having labels parameter and others not", () => {
+      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=cpu_usage value=85 ], [ var=memory_usage labels={instance=server1} value=70 ]";
+
+      const result = (transformer as any).parseValueString(valueString);
+
+      // Should group no-labels items together and labeled items separately
+      expect(result).toContain("max_queue_size=104, cpu_usage=85");
+      expect(result).toContain("[instance=server1] memory_usage=70");
+    });
+  });
 });

--- a/lambdas/collector/__tests__/transformers/grafana.test.ts
+++ b/lambdas/collector/__tests__/transformers/grafana.test.ts
@@ -400,7 +400,8 @@ describe("GrafanaTransformer", () => {
 
   describe("parseValueString", () => {
     it("should parse valueString with no labels", () => {
-      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=queue_size_threshold labels={} value=1 ]";
+      const valueString =
+        "[ var=max_queue_size labels={} value=104 ], [ var=queue_size_threshold labels={} value=1 ]";
 
       // Access private method through type assertion
       const result = (transformer as any).parseValueString(valueString);
@@ -409,47 +410,61 @@ describe("GrafanaTransformer", () => {
     });
 
     it("should parse valueString with labels and group by labels", () => {
-      const valueString = "[ var=cpu_usage labels={instance=server1,env=prod} value=85 ], [ var=memory_usage labels={instance=server1,env=prod} value=70 ], [ var=disk_usage labels={instance=server2,env=dev} value=45 ]";
+      const valueString =
+        "[ var=cpu_usage labels={instance=server1,env=prod} value=85 ], [ var=memory_usage labels={instance=server1,env=prod} value=70 ], [ var=disk_usage labels={instance=server2,env=dev} value=45 ]";
 
       const result = (transformer as any).parseValueString(valueString);
 
       // Should group by labels
-      expect(result).toContain("[instance=server1,env=prod] cpu_usage=85, memory_usage=70");
+      expect(result).toContain(
+        "[instance=server1,env=prod] cpu_usage=85, memory_usage=70",
+      );
       expect(result).toContain("[instance=server2,env=dev] disk_usage=45");
     });
 
     it("should handle mixed scenarios with some items having labels and others not", () => {
-      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=cpu_usage labels={instance=server1} value=85 ], [ var=disk_usage labels={instance=server1} value=70 ], [ var=threshold_breached labels={} value=1 ]";
+      const valueString =
+        "[ var=max_queue_size labels={} value=104 ], [ var=cpu_usage labels={instance=server1} value=85 ], [ var=disk_usage labels={instance=server1} value=70 ], [ var=threshold_breached labels={} value=1 ]";
 
       const result = (transformer as any).parseValueString(valueString);
 
       // No labels group
       expect(result).toContain("max_queue_size=104, threshold_breached=1");
       // Labeled group
-      expect(result).toContain("[instance=server1] cpu_usage=85, disk_usage=70");
+      expect(result).toContain(
+        "[instance=server1] cpu_usage=85, disk_usage=70",
+      );
     });
 
     it("should handle the example from the requirements", () => {
-      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=max_queue_time_mins labels={} value=7 ], [ var=queue_size_threshold labels={} value=1 ], [ var=queue_time_threshold labels={} value=0 ], [ var=threshold_breached labels={} value=1 ]";
+      const valueString =
+        "[ var=max_queue_size labels={} value=104 ], [ var=max_queue_time_mins labels={} value=7 ], [ var=queue_size_threshold labels={} value=1 ], [ var=queue_time_threshold labels={} value=0 ], [ var=threshold_breached labels={} value=1 ]";
 
       const result = (transformer as any).parseValueString(valueString);
 
-      expect(result).toBe("max_queue_size=104, max_queue_time_mins=7, queue_size_threshold=1, queue_time_threshold=0, threshold_breached=1");
+      expect(result).toBe(
+        "max_queue_size=104, max_queue_time_mins=7, queue_size_threshold=1, queue_time_threshold=0, threshold_breached=1",
+      );
     });
 
     it("should handle empty or invalid valueString", () => {
       expect((transformer as any).parseValueString("")).toBe("");
       expect((transformer as any).parseValueString(null)).toBe("");
       expect((transformer as any).parseValueString(undefined)).toBe("");
-      expect((transformer as any).parseValueString("invalid format")).toBe("invalid format");
+      expect((transformer as any).parseValueString("invalid format")).toBe(
+        "invalid format",
+      );
     });
 
     it("should handle valueString with complex label values", () => {
-      const valueString = "[ var=response_time labels={service=api,version=v1.2.3,region=us-east-1} value=250 ], [ var=error_rate labels={service=api,version=v1.2.3,region=us-east-1} value=0.5 ]";
+      const valueString =
+        "[ var=response_time labels={service=api,version=v1.2.3,region=us-east-1} value=250 ], [ var=error_rate labels={service=api,version=v1.2.3,region=us-east-1} value=0.5 ]";
 
       const result = (transformer as any).parseValueString(valueString);
 
-      expect(result).toBe("[service=api,version=v1.2.3,region=us-east-1] response_time=250, error_rate=0.5");
+      expect(result).toBe(
+        "[service=api,version=v1.2.3,region=us-east-1] response_time=250, error_rate=0.5",
+      );
     });
 
     it("should preserve original string if parsing fails", () => {
@@ -469,7 +484,8 @@ describe("GrafanaTransformer", () => {
     });
 
     it("should handle valueString without labels parameter (future-proofing)", () => {
-      const valueString = "[ var=max_queue_size value=104 ], [ var=queue_size_threshold value=1 ]";
+      const valueString =
+        "[ var=max_queue_size value=104 ], [ var=queue_size_threshold value=1 ]";
 
       const result = (transformer as any).parseValueString(valueString);
 
@@ -477,7 +493,8 @@ describe("GrafanaTransformer", () => {
     });
 
     it("should handle mixed format with some having labels parameter and others not", () => {
-      const valueString = "[ var=max_queue_size labels={} value=104 ], [ var=cpu_usage value=85 ], [ var=memory_usage labels={instance=server1} value=70 ]";
+      const valueString =
+        "[ var=max_queue_size labels={} value=104 ], [ var=cpu_usage value=85 ], [ var=memory_usage labels={instance=server1} value=70 ]";
 
       const result = (transformer as any).parseValueString(valueString);
 

--- a/lambdas/collector/src/transformers/grafana.ts
+++ b/lambdas/collector/src/transformers/grafana.ts
@@ -78,7 +78,10 @@ export class GrafanaTransformer extends BaseTransformer {
       title,
       description: this.sanitizeString(annotations.description || "", 1500),
       summary: this.sanitizeString(annotations.summary || "", 1500),
-      reason: this.sanitizeString(this.parseValueString(alert.valueString || ""), 500),
+      reason: this.sanitizeString(
+        this.parseValueString(alert.valueString || ""),
+        500,
+      ),
       priority,
       occurred_at: occurredAt,
       team,
@@ -162,17 +165,24 @@ export class GrafanaTransformer extends BaseTransformer {
 
     try {
       // Parse the valueString format: "[ var=name labels={key=value} value=123 ]" or "[ var=name value=123 ]"
-      const matches = valueString.match(/\[\s*var=([^,\s]+)(?:\s+labels=\{([^}]*)\})?\s+value=([^,\s\]]+)\s*\]/g);
+      const matches = valueString.match(
+        /\[\s*var=([^,\s]+)(?:\s+labels=\{([^}]*)\})?\s+value=([^,\s\]]+)\s*\]/g,
+      );
 
       if (!matches) {
         return valueString; // Return original if parsing fails
       }
 
-      const labelGroups = new Map<string, Array<{var: string, value: string}>>();
+      const labelGroups = new Map<
+        string,
+        Array<{ var: string; value: string }>
+      >();
 
       // Parse each match
       for (const match of matches) {
-        const innerMatch = match.match(/\[\s*var=([^,\s]+)(?:\s+labels=\{([^}]*)\})?\s+value=([^,\s\]]+)\s*\]/);
+        const innerMatch = match.match(
+          /\[\s*var=([^,\s]+)(?:\s+labels=\{([^}]*)\})?\s+value=([^,\s\]]+)\s*\]/,
+        );
 
         if (!innerMatch) continue;
 
@@ -194,7 +204,9 @@ export class GrafanaTransformer extends BaseTransformer {
 
       // Process each label group
       for (const [labels, items] of labelGroups) {
-        const varValuePairs = items.map(item => `${item.var}=${item.value}`).join(", ");
+        const varValuePairs = items
+          .map((item) => `${item.var}=${item.value}`)
+          .join(", ");
 
         if (labels) {
           // Group has labels - include them in the output

--- a/lambdas/collector/src/transformers/grafana.ts
+++ b/lambdas/collector/src/transformers/grafana.ts
@@ -78,7 +78,7 @@ export class GrafanaTransformer extends BaseTransformer {
       title,
       description: this.sanitizeString(annotations.description || "", 1500),
       summary: this.sanitizeString(annotations.summary || "", 1500),
-      reason: this.sanitizeString(alert.valueString || "", 500),
+      reason: this.sanitizeString(this.parseValueString(alert.valueString || ""), 500),
       priority,
       occurred_at: occurredAt,
       team,
@@ -153,6 +153,63 @@ export class GrafanaTransformer extends BaseTransformer {
     }
 
     return new Date().toISOString();
+  }
+
+  private parseValueString(valueString: string): string {
+    if (!valueString || typeof valueString !== "string") {
+      return "";
+    }
+
+    try {
+      // Parse the valueString format: "[ var=name labels={key=value} value=123 ]" or "[ var=name value=123 ]"
+      const matches = valueString.match(/\[\s*var=([^,\s]+)(?:\s+labels=\{([^}]*)\})?\s+value=([^,\s\]]+)\s*\]/g);
+
+      if (!matches) {
+        return valueString; // Return original if parsing fails
+      }
+
+      const labelGroups = new Map<string, Array<{var: string, value: string}>>();
+
+      // Parse each match
+      for (const match of matches) {
+        const innerMatch = match.match(/\[\s*var=([^,\s]+)(?:\s+labels=\{([^}]*)\})?\s+value=([^,\s\]]+)\s*\]/);
+
+        if (!innerMatch) continue;
+
+        const varName = innerMatch[1].trim();
+        const labels = innerMatch[2] ? innerMatch[2].trim() : ""; // Handle optional labels
+        const value = innerMatch[3].trim();
+
+        // Use labels as the grouping key (empty string for no labels)
+        const groupKey = labels;
+
+        if (!labelGroups.has(groupKey)) {
+          labelGroups.set(groupKey, []);
+        }
+
+        labelGroups.get(groupKey)!.push({ var: varName, value });
+      }
+
+      const result: string[] = [];
+
+      // Process each label group
+      for (const [labels, items] of labelGroups) {
+        const varValuePairs = items.map(item => `${item.var}=${item.value}`).join(", ");
+
+        if (labels) {
+          // Group has labels - include them in the output
+          result.push(`[${labels}] ${varValuePairs}`);
+        } else {
+          // No labels - just output the var=value pairs
+          result.push(varValuePairs);
+        }
+      }
+
+      return result.join("; ");
+    } catch (error) {
+      // If parsing fails, return the original string
+      return valueString;
+    }
   }
 
   // Extract debugging context for error messages


### PR DESCRIPTION
The old Grafana reason looked like this:

> [ var=max_queue_size labels={runner=linux.aws.h100} value=12 ], [ var=max_queue_time_mins labels={runner=linux.aws.h100} value=122 ], [ var=queue_size_threshold labels={runner=linux.aws.h100} value=0 ], [ var=queue_time_threshold labels={runner=linux.aws.h100} value=1 ], [ var=threshold_breached labels={runner=linux.aws.h100} value=1 ]

Now it'll look like:
> [runner=linux.aws.h100] max_queue_size=12, max_queue_time_mins=122, queue_size_threshold=0, queue_time_threshold=1, threshold_breached=1
