### PR TITLE
Add operations guide for alert configuration

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,104 @@
+# Adding New Alerts to the System
+
+This guide explains how to configure new alerts in Grafana and CloudWatch to work with our alert processing pipeline.
+
+## Overview
+
+The alert processing system expects specific labels/metadata to properly categorize alerts, assign ownership, and create meaningful GitHub issues. Without these required fields, alerts will fail to process.
+
+## Grafana Alerts
+
+### Required Labels
+
+These must be present in labels:
+
+- **`team`** - The owning team identifier (e.g., `dev-infra`, `training`, `ci`)
+- **`priority`** - Alert severity level: `P0`, `P1`, `P2`, or `P3`
+
+### Optional Labels
+
+- **`runbook_url`** - Link to troubleshooting documentation
+
+### Native Grafana Fields
+
+These are automatically picked up if present:
+- **`description`** - Alert description (native Grafana annotation)
+- **`summary`** - Alert summary (native Grafana annotation)
+
+### Configuration
+
+1. Create your alert rule in Grafana.  Give the outputs of the query meaningful names, otherwise Grafana will default to A, B, C
+2. Add the required fields in labels:
+   ```
+   team = dev-infra
+   priority = P1
+   runbook_url = https://wiki.example.com/runbooks/disk-space
+   ```
+3. Under "Configure Notification" enable "advanced options". Alerts will now get routed to our Dev and Prod channels
+
+### Example Configuration
+
+```yaml
+labels:
+  team: "dev-infra"
+  priority: "P1"
+  runbook_url: "https://wiki.pytorch.org/runbooks/disk-space"
+```
+
+## CloudWatch Alerts
+
+CloudWatch alerts use the AlarmDescription field to pass metadata in a specific format.
+
+### Required Fields
+
+These must be present in the AlarmDescription:
+
+- **`TEAM`** - Owning team identifier
+- **`PRIORITY`** - Priority level (`P0`, `P1`, `P2`, `P3`)
+
+### Optional Fields
+
+- **`RUNBOOK`** - Troubleshooting documentation URL
+
+### AlarmDescription Format
+
+The AlarmDescription should contain your alert description, followed by metadata in newline-separated key=value format:
+
+```
+High CPU usage detected on production instances
+TEAM=dev-infra
+PRIORITY=P1
+RUNBOOK=https://wiki.pytorch.org/runbooks/high-cpu
+```
+
+### Configuration
+
+1. Create your CloudWatch alarm
+2. Set the AlarmDescription with the required metadata format
+3. Configure the alarm to send to our SNS topic
+
+## Alert Processing Flow
+
+When properly configured alerts fire:
+
+1. Alert sent to SNS topic
+2. Queued through SQS to Lambda processor
+3. Normalized to canonical alert format
+4. GitHub issue created with appropriate labels
+5. Alert state tracked in DynamoDB
+
+The resulting GitHub issue includes:
+- Normalized title and description
+- Team and priority labels
+- Links to runbooks if provided
+- Debug information from original alert payload
+
+## Validation
+
+To verify your alert configuration:
+
+1. Check CloudWatch logs for the collector Lambda function
+2. Verify GitHub issue creation in the target repository
+3. Confirm alert state recorded in DynamoDB table
+
+Look for error messages about missing required fields if alerts fail to process. The logs include full alert payloads and processing details for debugging.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A production-ready alert normalization pipeline that processes CloudWatch and Gr
   - [Webhook Configuration](#webhook-configuration)
   - [Adding New Webhook Emitters](#adding-new-webhook-emitters)
   - [Alert Source Configuration](#alert-source-configuration)
+- [📋 Operations Guide](#-operations-guide)
 - [🏛️ Infrastructure Details](#️-infrastructure-details)
 - [📊 Monitoring & Observability](#-monitoring--observability)
 - [🔧 Troubleshooting](#-troubleshooting)
@@ -524,6 +525,12 @@ annotations:
   runbook_url: https://runbook.example.com
   description: Database connection pool exhausted
 ```
+
+## 📋 Operations Guide
+
+For detailed instructions on configuring new alerts in Grafana and CloudWatch, see [OPERATIONS.md](OPERATIONS.md).
+
+This guide covers how to add an new alert, with examples
 
 ## 🏛️ Infrastructure Details
 


### PR DESCRIPTION
## Summary

- Add OPERATIONS.md guide for configuring alerts in Grafana and CloudWatch
- Update README.md to reference the operations guide

## Changes

- **OPERATIONS.md**: Guide with required fields, examples, and validation steps
- **README.md**: Add reference to operations guide