### PR TITLE
Support multiple teams per alert

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -14,8 +14,8 @@ We map extra fields using what Grafana calls "Custom annotation name and content
 These must be present on every alert for it to fire:
 
 They're basically key/value pairs:
-- **`team`** - The owning team identifier (e.g., `pytorch-dev-infra`, `pytorch-benchmarking`)
-- **`priority`** - Alert severity level: `P0`, `P1`, `P2`, or `P3`
+- **`Teams`** - The owning team identifier(s). Supports multiple teams separated by commas (e.g., `pytorch-dev-infra, pytorch-benchmarking`)
+- **`Priority`** - Alert severity level: `P0`, `P1`, `P2`, or `P3`
 
 ### Optional Annotations
 
@@ -30,10 +30,10 @@ These fileds will also be populated in the alerts
 ### Configuration
 
 1. Create your alert rule in Grafana.  Give the outputs of the query meaningful names, otherwise Grafana will default to A, B, C
-2. Add the required fields in labels:
+2. Add the required fields in annotations:
    ```
-   team = dev-infra
-   priority = P1
+   Teams = dev-infra, platform
+   Priority = P1
    runbook_url = https://wiki.example.com/runbooks/disk-space
    ```
 3. Under "Configure Notification" enable "advanced options". Alerts will now get routed to our Dev and Prod channels
@@ -41,9 +41,9 @@ These fileds will also be populated in the alerts
 ### Example Configuration
 
 ```yaml
-labels:
-  team: "dev-infra"
-  priority: "P1"
+annotations:
+  Teams: "dev-infra, platform"
+  Priority: "P1"
   runbook_url: "https://wiki.pytorch.org/runbooks/disk-space"
 ```
 
@@ -55,7 +55,7 @@ CloudWatch alerts use the AlarmDescription field to pass metadata in a specific 
 
 These must be present in the AlarmDescription:
 
-- **`TEAM`** - Owning team identifier
+- **`TEAMS`** - Owning team identifier(s). Supports multiple teams separated by commas
 - **`PRIORITY`** - Priority level (`P0`, `P1`, `P2`, `P3`)
 
 ### Optional Fields
@@ -68,7 +68,7 @@ The AlarmDescription should contain your alert description, followed by metadata
 
 ```
 High CPU usage detected on production instances
-TEAM=dev-infra
+TEAMS=dev-infra, platform
 PRIORITY=P1
 RUNBOOK=https://wiki.pytorch.org/runbooks/high-cpu
 ```
@@ -91,7 +91,7 @@ When properly configured alerts fire:
 
 The resulting GitHub issue includes:
 - Normalized title and description
-- Team and priority labels
+- Multiple team labels (Team:dev-infra, Team:platform, etc.) and priority labels
 - Links to runbooks if provided
 - Debug information from original alert payload
 

--- a/lambdas/collector/__tests__/basic-functionality.test.ts
+++ b/lambdas/collector/__tests__/basic-functionality.test.ts
@@ -31,7 +31,7 @@ describe("Basic Functionality Tests", () => {
       expect(result.source).toBe("grafana");
       expect(result.state).toBe("FIRING");
       expect(result.title).toBe("Test Alert");
-      expect(result.team).toBe("dev-infra");
+      expect(result.teams).toEqual(["dev-infra"]);
       expect(result.priority).toBe("P1");
     });
 
@@ -63,7 +63,7 @@ describe("Basic Functionality Tests", () => {
       expect(result.source).toBe("cloudwatch");
       expect(result.state).toBe("FIRING");
       expect(result.title).toBe("High CPU Usage");
-      expect(result.team).toBe("platform");
+      expect(result.teams).toEqual(["platform"]);
       expect(result.priority).toBe("P2");
     });
 

--- a/lambdas/collector/__tests__/multi-team-support.test.ts
+++ b/lambdas/collector/__tests__/multi-team-support.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GrafanaTransformer } from "../src/transformers/grafana";
+import { CloudWatchTransformer } from "../src/transformers/cloudwatch";
+import { Envelope } from "../src/types";
+import {
+  testGrafanaPayloads,
+  testCloudWatchPayloads,
+} from "./utils/test-fixtures";
+
+describe("Multi-Team Support", () => {
+  let mockEnvelope: Envelope;
+
+  beforeEach(() => {
+    mockEnvelope = {
+      received_at: "2025-09-16T12:00:00.000Z",
+      ingest_topic: "test-topic",
+      ingest_region: "us-east-1",
+      delivery_attempt: 1,
+      event_id: "test-event-123",
+    };
+  });
+
+  describe("GrafanaTransformer Multi-Team Support", () => {
+    let transformer: GrafanaTransformer;
+
+    beforeEach(() => {
+      transformer = new GrafanaTransformer();
+    });
+
+    it("should handle multi-team alert with TEAMS annotation", () => {
+      const result = transformer.transform(
+        testGrafanaPayloads.multiTeamFiring,
+        mockEnvelope,
+      );
+
+      expect(result.teams).toEqual(["dev-infra", "platform", "security"]);
+      expect(result.priority).toBe("P0");
+      expect(result.title).toBe("Multi-Team Alert");
+    });
+
+    it("should handle team names with spaces", () => {
+      const result = transformer.transform(
+        testGrafanaPayloads.multiTeamWithSpaces,
+        mockEnvelope,
+      );
+
+      expect(result.teams).toEqual([
+        "pytorch-dev-infra",
+        "intel-infra",
+        "ml-platform",
+      ]);
+      expect(result.priority).toBe("P1");
+    });
+
+    it("should handle single team using TEAMS keyword", () => {
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P2",
+              Teams: "single-team",
+              description: "Single team using Teams annotation",
+            },
+          },
+        ],
+      };
+
+      const result = transformer.transform(payload, mockEnvelope);
+
+      expect(result.teams).toEqual(["single-team"]);
+      expect(result.priority).toBe("P2");
+    });
+
+    it("should prioritize TEAMS over TEAM annotation", () => {
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P1",
+              Team: "old-team",
+              Teams: "new-team1, new-team2",
+              description: "Testing priority of TEAMS over TEAM",
+            },
+          },
+        ],
+      };
+
+      const result = transformer.transform(payload, mockEnvelope);
+
+      expect(result.teams).toEqual(["new-team1", "new-team2"]);
+      expect(result.priority).toBe("P1");
+    });
+
+    it("should handle case-insensitive team keywords", () => {
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P1",
+              teams: "case-insensitive1, case-insensitive2", // lowercase
+              description: "Testing case insensitive teams",
+            },
+          },
+        ],
+      };
+
+      const result = transformer.transform(payload, mockEnvelope);
+
+      expect(result.teams).toEqual(["case-insensitive1", "case-insensitive2"]);
+    });
+  });
+
+  describe("CloudWatchTransformer Multi-Team Support", () => {
+    let transformer: CloudWatchTransformer;
+
+    beforeEach(() => {
+      transformer = new CloudWatchTransformer();
+    });
+
+    it("should handle multi-team alarm with TEAMS field", () => {
+      const result = transformer.transform(
+        testCloudWatchPayloads.multiTeamAlarm,
+        mockEnvelope,
+      );
+
+      expect(result.teams).toEqual(["dev-infra", "platform", "security"]);
+      expect(result.priority).toBe("P0");
+      expect(result.title).toBe("Critical Multi-Team Issue");
+    });
+
+    it("should handle backward compatibility with TEAM field", () => {
+      const result = transformer.transform(
+        testCloudWatchPayloads.legacySingleTeamAlarm,
+        mockEnvelope,
+      );
+
+      expect(result.teams).toEqual(["legacy-team"]);
+      expect(result.priority).toBe("P2");
+      expect(result.title).toBe("Legacy Single Team Alert");
+    });
+
+    it("should prioritize TEAMS over TEAM in AlarmDescription", () => {
+      const alarmData = JSON.parse(testCloudWatchPayloads.alarm.Message);
+      const customAlarm = {
+        ...testCloudWatchPayloads.alarm,
+        Message: JSON.stringify({
+          ...alarmData,
+          AlarmDescription: `
+            Multi-team test alert
+            TEAM=old-team
+            TEAMS=new-team1, new-team2
+            PRIORITY=P1
+          `,
+        }),
+      };
+
+      const result = transformer.transform(customAlarm, mockEnvelope);
+
+      expect(result.teams).toEqual(["new-team1", "new-team2"]);
+      expect(result.priority).toBe("P1");
+    });
+
+    it("should handle pipe-separated format with TEAMS", () => {
+      const alarmData = JSON.parse(testCloudWatchPayloads.alarm.Message);
+      const customAlarm = {
+        ...testCloudWatchPayloads.alarm,
+        Message: JSON.stringify({
+          ...alarmData,
+          AlarmDescription:
+            "TEAMS=team1, team2, team3 | PRIORITY=P1 | RUNBOOK=https://example.com",
+        }),
+      };
+
+      const result = transformer.transform(customAlarm, mockEnvelope);
+
+      expect(result.teams).toEqual(["team1", "team2", "team3"]);
+      expect(result.priority).toBe("P1");
+    });
+  });
+
+  describe("Team Name Normalization", () => {
+    let grafanaTransformer: GrafanaTransformer;
+    let cloudwatchTransformer: CloudWatchTransformer;
+
+    beforeEach(() => {
+      grafanaTransformer = new GrafanaTransformer();
+      cloudwatchTransformer = new CloudWatchTransformer();
+    });
+
+    it("should normalize team names with spaces to hyphens in Grafana", () => {
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P1",
+              Teams: "PyTorch Dev Infra, Intel Platform Team",
+              description: "Testing space normalization",
+            },
+          },
+        ],
+      };
+
+      const result = grafanaTransformer.transform(payload, mockEnvelope);
+
+      expect(result.teams).toEqual([
+        "pytorch-dev-infra",
+        "intel-platform-team",
+      ]);
+    });
+
+    it("should normalize team names with spaces to hyphens in CloudWatch", () => {
+      const alarmData = JSON.parse(testCloudWatchPayloads.alarm.Message);
+      const customAlarm = {
+        ...testCloudWatchPayloads.alarm,
+        Message: JSON.stringify({
+          ...alarmData,
+          AlarmDescription:
+            "TEAMS=PyTorch Dev Infra, Intel Platform Team\nPRIORITY=P1",
+        }),
+      };
+
+      const result = cloudwatchTransformer.transform(customAlarm, mockEnvelope);
+
+      expect(result.teams).toEqual([
+        "pytorch-dev-infra",
+        "intel-platform-team",
+      ]);
+    });
+  });
+
+  describe("Error Handling for Multi-Team", () => {
+    let grafanaTransformer: GrafanaTransformer;
+    let cloudwatchTransformer: CloudWatchTransformer;
+
+    beforeEach(() => {
+      grafanaTransformer = new GrafanaTransformer();
+      cloudwatchTransformer = new CloudWatchTransformer();
+    });
+
+    it("should reject empty teams list in Grafana", () => {
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P1",
+              Teams: ",  , , ", // Commas but no actual team names
+            },
+          },
+        ],
+      };
+
+      expect(() => {
+        grafanaTransformer.transform(payload, mockEnvelope);
+      }).toThrow(
+        "No valid team names found after parsing comma-delimited list",
+      );
+    });
+
+    it("should reject empty teams list in CloudWatch", () => {
+      const alarmData = JSON.parse(testCloudWatchPayloads.alarm.Message);
+      const customAlarm = {
+        ...testCloudWatchPayloads.alarm,
+        Message: JSON.stringify({
+          ...alarmData,
+          AlarmDescription: "TEAMS=,,,\nPRIORITY=P1", // Commas but no actual team names
+        }),
+      };
+
+      expect(() => {
+        cloudwatchTransformer.transform(customAlarm, mockEnvelope);
+      }).toThrow(
+        "No valid team names found after parsing comma-delimited list",
+      );
+    });
+
+    it("should reject too many teams (> 10)", () => {
+      const manyTeams = Array.from(
+        { length: 11 },
+        (_, i) => `team${i + 1}`,
+      ).join(", ");
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P1",
+              Teams: manyTeams,
+            },
+          },
+        ],
+      };
+
+      expect(() => {
+        grafanaTransformer.transform(payload, mockEnvelope);
+      }).toThrow("Too many teams specified (max 10, got 11)");
+    });
+
+    it("should reject team names that are too long (> 50 chars)", () => {
+      const longTeamName = "a".repeat(51);
+      const payload = {
+        ...testGrafanaPayloads.firing,
+        alerts: [
+          {
+            ...testGrafanaPayloads.firing.alerts[0],
+            annotations: {
+              Priority: "P1",
+              Teams: longTeamName,
+            },
+          },
+        ],
+      };
+
+      expect(() => {
+        grafanaTransformer.transform(payload, mockEnvelope);
+      }).toThrow("Team name too long (max 50 characters)");
+    });
+  });
+});

--- a/lambdas/collector/__tests__/transformers/base.test.ts
+++ b/lambdas/collector/__tests__/transformers/base.test.ts
@@ -15,7 +15,7 @@ class TestTransformer extends BaseTransformer {
       reason: "",
       priority: this.extractPriority(rawPayload.priority),
       occurred_at: this.parseTimestamp(rawPayload.timestamp),
-      team: this.extractTeam(rawPayload.team),
+      teams: this.extractTeams(rawPayload.teams),
       identity: { account_id: "", alarm_id: "" },
       links: {},
       raw_provider: rawPayload,
@@ -213,33 +213,35 @@ describe("BaseTransformer", () => {
     });
   });
 
-  describe("extractTeam", () => {
+  describe("extractTeams", () => {
     it("should extract and normalize team names", () => {
-      expect(transformer["extractTeam"]("DevOps")).toBe("devops");
-      expect(transformer["extractTeam"]("DEV-INFRA")).toBe("dev-infra");
+      expect(transformer["extractTeams"]("DevOps")).toEqual(["devops"]);
+      expect(transformer["extractTeams"]("DEV-INFRA")).toEqual(["dev-infra"]);
     });
 
     it("should replace spaces with hyphens for tooling compatibility", () => {
-      expect(transformer["extractTeam"]("Platform Team")).toBe("platform-team");
-      expect(transformer["extractTeam"](" Multi  Word Team ")).toBe(
+      expect(transformer["extractTeams"]("Platform Team")).toEqual([
+        "platform-team",
+      ]);
+      expect(transformer["extractTeams"](" Multi  Word Team ")).toEqual([
         "multi-word-team",
-      );
+      ]);
     });
 
     it("should trim whitespace", () => {
-      expect(transformer["extractTeam"](" dev-infra ")).toBe("dev-infra");
-      expect(transformer["extractTeam"]("  PLATFORM  ")).toBe("platform");
+      expect(transformer["extractTeams"](" dev-infra ")).toEqual(["dev-infra"]);
+      expect(transformer["extractTeams"]("  PLATFORM  ")).toEqual(["platform"]);
     });
 
     it("should throw error for empty team names", () => {
-      expect(() => transformer["extractTeam"]("")).toThrow(
-        "Team field is empty or missing",
+      expect(() => transformer["extractTeams"]("")).toThrow(
+        "Teams field is empty or missing",
       );
-      expect(() => transformer["extractTeam"]("   ")).toThrow(
-        "Team field is empty or missing",
+      expect(() => transformer["extractTeams"]("   ")).toThrow(
+        "Teams field is empty or missing",
       );
-      expect(() => transformer["extractTeam"](null as any)).toThrow(
-        "Team field is empty or missing",
+      expect(() => transformer["extractTeams"](null as any)).toThrow(
+        "Teams field is empty or missing",
       );
     });
   });

--- a/lambdas/collector/__tests__/transformers/cloudwatch.test.ts
+++ b/lambdas/collector/__tests__/transformers/cloudwatch.test.ts
@@ -31,7 +31,7 @@ describe("CloudWatchTransformer", () => {
         state: "FIRING",
         title: "High CPU Usage",
         priority: "P2",
-        team: "platform",
+        teams: ["platform"],
         identity: {
           account_id: "123456789012",
           region: "us-east-1",
@@ -91,7 +91,7 @@ describe("CloudWatchTransformer", () => {
 
       const result = transformer.transform(customAlarm, mockEnvelope);
 
-      expect(result.team).toBe("devops");
+      expect(result.teams).toEqual(["devops"]);
       expect(result.priority).toBe("P1");
       expect(result.links?.runbook_url).toBe(
         "https://runbooks.example.com/cpu",
@@ -112,7 +112,7 @@ describe("CloudWatchTransformer", () => {
 
       const result = transformer.transform(customAlarm, mockEnvelope);
 
-      expect(result.team).toBe("devops");
+      expect(result.teams).toEqual(["devops"]);
       expect(result.priority).toBe("P1");
       expect(result.links?.runbook_url).toBe(
         "https://runbooks.example.com/cpu",
@@ -237,7 +237,7 @@ describe("CloudWatchTransformer", () => {
       };
 
       expect(() => transformer.transform(invalidAlarm, mockEnvelope)).toThrow(
-        'Missing required field "TEAM"',
+        'Missing required field "TEAMS"',
       );
     });
 
@@ -265,8 +265,8 @@ describe("CloudWatchTransformer", () => {
 
       const result = transformer.transform(customAlarm, mockEnvelope);
 
-      expect(result.team).not.toContain("<script>");
-      expect(result.team).toBe("scriptalert(xss)/scriptplatform");
+      expect(result.teams).toEqual(["scriptalert(xss)/scriptplatform"]);
+      expect(result.teams[0]).not.toContain("<script>");
       expect(result.links?.runbook_url).toBeUndefined(); // Invalid URL should be filtered
       expect(result.description).toContain(
         "Description with quotes and apostrophes",
@@ -292,7 +292,7 @@ describe("CloudWatchTransformer", () => {
 
       const result = transformer.transform(customAlarm, mockEnvelope);
 
-      expect(result.team).toBe("platform");
+      expect(result.teams).toEqual(["platform"]);
       expect(result.priority).toBe("P1");
       expect(result.links?.runbook_url).toBe(
         "https://runbooks.example.com/test",

--- a/lambdas/collector/__tests__/transformers/grafana.test.ts
+++ b/lambdas/collector/__tests__/transformers/grafana.test.ts
@@ -32,7 +32,7 @@ describe("GrafanaTransformer", () => {
         title: "Test Alert",
         description: "Test alert description",
         priority: "P1",
-        team: "dev-infra",
+        teams: ["dev-infra"],
         identity: {
           account_id: "1",
           alarm_id: "abc123",
@@ -57,7 +57,7 @@ describe("GrafanaTransformer", () => {
         state: "RESOLVED",
         title: "Test Alert",
         priority: "P1",
-        team: "dev-infra",
+        teams: ["dev-infra"],
       });
     });
 
@@ -81,7 +81,7 @@ describe("GrafanaTransformer", () => {
 
       const result = transformer.transform(payload, mockEnvelope);
 
-      expect(result.team).toBe("platform-team");
+      expect(result.teams).toEqual(["platform-team"]);
       expect(result.priority).toBe("P2");
     });
 
@@ -393,7 +393,7 @@ describe("GrafanaTransformer", () => {
         };
 
         const result = transformer.transform(payload, mockEnvelope);
-        expect(result.team).toBe(expected);
+        expect(result.teams).toEqual([expected]);
       });
     });
   });

--- a/lambdas/collector/__tests__/transformers/normalized.test.ts
+++ b/lambdas/collector/__tests__/transformers/normalized.test.ts
@@ -15,7 +15,7 @@ describe("NormalizedTransformer", () => {
     summary: "Critical CPU alert",
     priority: "P1",
     occurred_at: "2024-01-15T10:30:00.000Z",
-    team: "platform-team",
+    teams: ["platform-team"],
     identity: {
       account_id: "123456789012",
       region: "us-west-2",
@@ -48,7 +48,7 @@ describe("NormalizedTransformer", () => {
       expect(result.source).toBe("datadog");
       expect(result.state).toBe("FIRING");
       expect(result.priority).toBe("P1");
-      expect(result.team).toBe("platform-team");
+      expect(result.teams).toEqual(["platform-team"]);
     });
 
     it("should handle RESOLVED state", () => {
@@ -103,7 +103,7 @@ describe("NormalizedTransformer", () => {
         "title",
         "priority",
         "occurred_at",
-        "team",
+        "teams",
         "identity",
         "links",
       ];

--- a/lambdas/collector/__tests__/utils/schema-validator.test.ts
+++ b/lambdas/collector/__tests__/utils/schema-validator.test.ts
@@ -14,7 +14,7 @@ describe("Schema Validator", () => {
     title: "Test Alert",
     priority: "P1",
     occurred_at: "2024-01-15T10:30:00.000Z",
-    team: "test-team",
+    teams: ["test-team"],
     identity: {
       alarm_id: "test-rule",
     },

--- a/lambdas/collector/__tests__/utils/test-fixtures.ts
+++ b/lambdas/collector/__tests__/utils/test-fixtures.ts
@@ -35,7 +35,7 @@ export const testAlertEvents = {
     reason: "Test reason",
     priority: "P1" as const,
     occurred_at: "2025-09-16T12:00:00.000Z",
-    team: "dev-infra",
+    teams: ["dev-infra"],
     identity: {
       account_id: "1",
       alarm_id: "test-rule-123",
@@ -57,7 +57,7 @@ export const testAlertEvents = {
     reason: "Test reason",
     priority: "P1" as const,
     occurred_at: "2025-09-16T12:05:00.000Z",
-    team: "dev-infra",
+    teams: ["dev-infra"],
     identity: {
       account_id: "1",
       alarm_id: "test-rule-123",
@@ -79,7 +79,7 @@ export const testAlertEvents = {
     reason: "Threshold crossed",
     priority: "P2" as const,
     occurred_at: "2025-09-16T12:00:00.000Z",
-    team: "platform",
+    teams: ["platform"],
     identity: {
       account_id: "123456789012",
       alarm_id: "arn:aws:cloudwatch:us-east-1:123456789012:alarm:HighCPU",
@@ -87,6 +87,29 @@ export const testAlertEvents = {
     links: {
       source_url:
         "https://console.aws.amazon.com/cloudwatch/home#alarmsV2:alarm/HighCPU",
+    },
+    raw_provider: {},
+  } satisfies AlertEvent,
+
+  // New multi-team test fixtures
+  multiTeamAlert: {
+    schema_version: 1,
+    source: "grafana",
+    state: "FIRING" as const,
+    title: "Multi-Team Alert",
+    description: "Alert that affects multiple teams",
+    reason: "Test multi-team reason",
+    priority: "P1" as const,
+    occurred_at: "2025-09-16T12:00:00.000Z",
+    teams: ["dev-infra", "platform", "security"],
+    identity: {
+      account_id: "1",
+      alarm_id: "multi-team-rule-456",
+    },
+    links: {
+      runbook_url: "https://runbooks.example.com/multi-team",
+      dashboard_url: "https://grafana.example.com/multi-dashboard",
+      source_url: "https://grafana.example.com/multi-alert",
     },
     raw_provider: {},
   } satisfies AlertEvent,
@@ -195,6 +218,75 @@ export const testGrafanaPayloads = {
     state: "alerting",
     message: "Test message",
   },
+
+  // New multi-team payloads for testing
+  multiTeamFiring: {
+    receiver: "sns",
+    status: "firing",
+    orgId: 1,
+    alerts: [
+      {
+        status: "firing",
+        labels: {
+          alertname: "Multi-Team Alert",
+        },
+        annotations: {
+          Priority: "P0",
+          Teams: "dev-infra, platform, security", // Multi-team using TEAMS keyword
+          description: "Alert affecting multiple teams",
+          runbook_url: "https://runbooks.example.com/multi-team",
+          summary: "Critical multi-team alert",
+        },
+        startsAt: "2025-09-16T12:00:00.000Z",
+        endsAt: "0001-01-01T00:00:00Z",
+        generatorURL: "https://grafana.example.com/multi-alert",
+        fingerprint: "multi123",
+      },
+    ],
+    groupLabels: { alertname: "Multi-Team Alert" },
+    commonLabels: {},
+    commonAnnotations: {},
+    externalURL: "https://grafana.example.com",
+    version: "1",
+    groupKey: '{}:{alertname="Multi-Team Alert"}',
+    truncatedAlerts: 0,
+    title: "[FIRING:1] Multi-Team Alert",
+    state: "alerting",
+    message: "Multi-team test message",
+  },
+
+  multiTeamWithSpaces: {
+    receiver: "sns",
+    status: "firing",
+    orgId: 1,
+    alerts: [
+      {
+        status: "firing",
+        labels: {
+          alertname: "Space Team Alert",
+        },
+        annotations: {
+          Priority: "P1",
+          teams: "pytorch dev-infra, intel-infra, ml platform", // Teams with spaces
+          description: "Alert with team names containing spaces",
+        },
+        startsAt: "2025-09-16T12:00:00.000Z",
+        endsAt: "0001-01-01T00:00:00Z",
+        generatorURL: "https://grafana.example.com/space-alert",
+        fingerprint: "space456",
+      },
+    ],
+    groupLabels: { alertname: "Space Team Alert" },
+    commonLabels: {},
+    commonAnnotations: {},
+    externalURL: "https://grafana.example.com",
+    version: "1",
+    groupKey: '{}:{alertname="Space Team Alert"}',
+    truncatedAlerts: 0,
+    title: "[FIRING:1] Space Team Alert",
+    state: "alerting",
+    message: "Space team test message",
+  },
 };
 
 // Test CloudWatch payloads
@@ -262,6 +354,51 @@ export const testCloudWatchPayloads = {
       },
     }),
     Timestamp: "2025-09-16T12:05:00.123Z",
+    SignatureVersion: "1",
+  },
+
+  // Multi-team CloudWatch payloads for testing
+  multiTeamAlarm: {
+    Type: "Notification",
+    MessageId: "87654321-4321-4321-4321-210987654321",
+    TopicArn: "arn:aws:sns:us-east-1:123456789012:alerts",
+    Subject: "ALARM: Critical Multi-Team Issue in US East - N. Virginia",
+    Message: JSON.stringify({
+      AlarmName: "Critical Multi-Team Issue",
+      AlarmDescription:
+        "Critical infrastructure failure affecting multiple teams\nTEAMS=dev-infra, platform, security\nPRIORITY=P0\nRUNBOOK=https://runbooks.example.com/multi-team-critical",
+      AWSAccountId: "123456789012",
+      NewStateValue: "ALARM",
+      NewStateReason: "Critical infrastructure failure detected",
+      StateChangeTime: "2025-09-16T12:00:00.000Z",
+      Region: "US East - N. Virginia",
+      AlarmArn:
+        "arn:aws:cloudwatch:us-east-1:123456789012:alarm:CriticalMultiTeam",
+      OldStateValue: "OK",
+    }),
+    Timestamp: "2025-09-16T12:00:00.123Z",
+    SignatureVersion: "1",
+  },
+
+  legacySingleTeamAlarm: {
+    Type: "Notification",
+    MessageId: "11111111-2222-3333-4444-555555555555",
+    TopicArn: "arn:aws:sns:us-east-1:123456789012:alerts",
+    Subject: "ALARM: Legacy Single Team Alert in US East - N. Virginia",
+    Message: JSON.stringify({
+      AlarmName: "Legacy Single Team Alert",
+      AlarmDescription:
+        "Legacy alert using old TEAM format for backward compatibility\nTEAM=legacy-team\nPRIORITY=P2\nRUNBOOK=https://runbooks.example.com/legacy",
+      AWSAccountId: "123456789012",
+      NewStateValue: "ALARM",
+      NewStateReason: "Legacy system alert",
+      StateChangeTime: "2025-09-16T12:00:00.000Z",
+      Region: "US East - N. Virginia",
+      AlarmArn:
+        "arn:aws:cloudwatch:us-east-1:123456789012:alarm:LegacySingleTeam",
+      OldStateValue: "OK",
+    }),
+    Timestamp: "2025-09-16T12:00:00.123Z",
     SignatureVersion: "1",
   },
 };

--- a/lambdas/collector/schemas/README.md
+++ b/lambdas/collector/schemas/README.md
@@ -41,7 +41,7 @@ const alert = {
   title: "High CPU Usage",
   priority: "P1",
   occurred_at: "2024-01-15T10:30:00.000Z",
-  team: "platform-team",
+  teams: ["platform-team"],
   identity: { account_id: "123456789012", alarm_id: "cpu-high" },
   links: { runbook_url: "https://wiki.company.com/cpu-runbook" },
 };
@@ -71,7 +71,7 @@ alert = {
     "title": "High CPU Usage",
     "priority": "P1",
     "occurred_at": "2024-01-15T10:30:00.000Z",
-    "team": "platform-team",
+    "teams": ["platform-team"],
     "identity": {"account_id": "123456789012", "alarm_id": "cpu-high"},
     "links": {"runbook_url": "https://wiki.company.com/cpu-runbook"}
 }
@@ -104,7 +104,7 @@ func main() {
         "title":          "High CPU Usage",
         "priority":       "P1",
         "occurred_at":    "2024-01-15T10:30:00.000Z",
-        "team":           "platform-team",
+        "teams":          []string{"platform-team"},
         "identity":       map[string]interface{}{"account_id": "123456789012", "alarm_id": "cpu-high"},
         "links":          map[string]interface{}{"runbook_url": "https://wiki.company.com/cpu-runbook"},
     }
@@ -138,7 +138,7 @@ func main() {
 | `title`          | string  | Alert title (max 500 chars)  |
 | `priority`       | enum    | "P0", "P1", "P2", or "P3"    |
 | `occurred_at`    | string  | ISO8601 timestamp            |
-| `team`           | string  | Owning team identifier       |
+| `teams`          | array   | Owning team identifiers      |
 | `identity`       | object  | Identity for fingerprinting  |
 | `links`          | object  | Navigation links             |
 
@@ -155,8 +155,13 @@ func main() {
 
 - **URLs**: Must be valid HTTP/HTTPS URLs (max 2048 chars)
 - **Account ID**: Alphanumeric, hyphens, underscores only (max 100 chars)
-- **CloudWatch ARN**: Must start with "arn:aws:cloudwatch:"
-- **Source/Team**: Alphanumeric, hyphens, underscores only
+- **Teams**: Array of 1-10 team names, each max 50 chars, alphanumeric/hyphens/underscores only
+- **Source**: Alphanumeric, hyphens, underscores only (max 50 chars)
+- **Title**: Max 500 characters
+- **Description**: Max 4000 characters
+- **Summary**: Max 1000 characters
+- **Reason**: Max 2000 characters
+- **Alarm ID**: Any string up to 1024 characters (CloudWatch ARN, Grafana rule ID, etc.)
 
 ## 🔄 Schema Evolution
 

--- a/lambdas/collector/schemas/alert-event.schema.json
+++ b/lambdas/collector/schemas/alert-event.schema.json
@@ -54,12 +54,17 @@
       "format": "date-time",
       "description": "ISO8601 timestamp of when the alert state changed"
     },
-    "team": {
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 100,
-      "pattern": "^[a-zA-Z0-9_-]+$",
-      "description": "Owning team identifier (normalized with hyphens)"
+    "teams": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 10,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50,
+        "pattern": "^[a-zA-Z0-9_-]+$"
+      },
+      "description": "Owning team identifiers (normalized with hyphens)"
     },
     "identity": {
       "type": "object",
@@ -128,7 +133,7 @@
     "title",
     "priority",
     "occurred_at",
-    "team",
+    "teams",
     "identity",
     "links"
   ],
@@ -143,7 +148,7 @@
       "summary": "Critical CPU alert on production web server",
       "priority": "P1",
       "occurred_at": "2024-01-15T10:30:00.000Z",
-      "team": "platform-team",
+      "teams": ["platform-team"],
       "identity": {
         "account_id": "123456789012",
         "region": "us-west-2",

--- a/lambdas/collector/src/github/githubClient.ts
+++ b/lambdas/collector/src/github/githubClient.ts
@@ -224,6 +224,18 @@ export class GitHubClient {
     }
   }
 
+  async ensureTeamLabels(teams: string[]): Promise<void> {
+    if (!this.githubRepo) throw new Error("GITHUB_REPO not set");
+    const [owner, repo] = this.githubRepo.split("/");
+    const token = await this.getInstallationToken();
+
+    // Create Team:X labels for each team
+    for (const team of teams) {
+      const labelName = `Team:${team}`;
+      await this.ensureGithubLabel(owner, repo, token, labelName, "1f883d");
+    }
+  }
+
   async createGithubIssue(
     title: string,
     body: string,

--- a/lambdas/collector/src/processor.ts
+++ b/lambdas/collector/src/processor.ts
@@ -53,7 +53,7 @@ export class AlertProcessor {
         metadata: {
           alertEvent,
           source: alertEvent.source,
-          team: alertEvent.team,
+          teams: alertEvent.teams,
           priority: alertEvent.priority,
           state: alertEvent.state,
         },

--- a/lambdas/collector/src/transformers/normalized.ts
+++ b/lambdas/collector/src/transformers/normalized.ts
@@ -31,7 +31,7 @@ export class NormalizedTransformer extends BaseTransformer {
       console.log("Processed normalized alert", {
         source: alertEvent.source,
         title: alertEvent.title,
-        team: alertEvent.team,
+        teams: alertEvent.teams,
         priority: alertEvent.priority,
         state: alertEvent.state,
         schema_version: alertEvent.schema_version,

--- a/lambdas/collector/src/types.ts
+++ b/lambdas/collector/src/types.ts
@@ -35,7 +35,7 @@ export interface AlertEvent {
   reason?: string; // provider-specific reason/message (NewStateReason for CloudWatch, message for Grafana)
   priority: "P0" | "P1" | "P2" | "P3"; // single canonical concept; no severity field
   occurred_at: string; // provider state change time (ISO8601)
-  team: string; // owning team slug (single team in v1)
+  teams: string[]; // owning team slugs (supports multiple teams)
   identity: AlertIdentity;
   links: AlertLinks;
   raw_provider?: any; // minimally transformed provider payload for debugging
@@ -46,7 +46,7 @@ export interface AlertEvent {
 export interface AlertState {
   fingerprint: string; // Primary key
   status: "OPEN" | "CLOSED";
-  team: string;
+  teams: string[];
   priority: "P0" | "P1" | "P2" | "P3";
   title: string;
   issue_repo: string; // "pytorch/test-infra"


### PR DESCRIPTION
Now you can specify the value of TEAM with a comma separated list of teams, and a separate `TEAM:abc` label will be applied to the github issue for each team.
Both TEAM and TEAMS keyword are accepted interchangably here, so you can set `TEAMS=abc,xyc` or `TEAM=abc`