### PR TITLE
Allow collector lambda to handle pre-normalized alerts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,3 +7,5 @@
 - [ ] Create test suite for webhook Lambda authentication and SNS publishing
 - [ ] Add GitHub workflow based deployment system
 - [ ] Move security/string sanitization methods to their own utility file
+- [ ] Fix documentation for team vs teams
+- [ ] Better handling for normalized webhooks in the external-alerts-webhook lambda?

--- a/lambdas/collector/__tests__/transformers/source-detection.test.ts
+++ b/lambdas/collector/__tests__/transformers/source-detection.test.ts
@@ -44,7 +44,7 @@ describe("Source Detection", () => {
         title: "Test Alert",
         priority: "P1",
         occurred_at: "2024-01-15T10:30:00.000Z",
-        team: "platform-team",
+        teams: ["platform-team"],
         identity: {},
         links: {},
       };

--- a/lambdas/collector/src/processor.ts
+++ b/lambdas/collector/src/processor.ts
@@ -100,11 +100,9 @@ export class AlertProcessor {
     rawPayload: any,
     envelope: Envelope,
   ): Promise<AlertEvent> {
-    // Get the appropriate transformer based on payload analysis
-    const source = this.detectSourceFromPayload(rawPayload);
     const transformer = getTransformerForRecord({
       body: JSON.stringify(rawPayload),
-      messageAttributes: { source: { stringValue: source } },
+      messageAttributes: { source: { stringValue: undefined } },
     } as any);
 
     return transformer.transform(rawPayload, envelope);
@@ -234,42 +232,5 @@ export class AlertProcessor {
     }
 
     return "unknown";
-  }
-
-  // Detect source from raw payload structure - improved detection logic
-  private detectSourceFromPayload(rawPayload: any): string {
-    if (!rawPayload || typeof rawPayload !== "object") {
-      throw new Error("Invalid payload: not an object");
-    }
-
-    // Check for Grafana-specific fields
-    if (
-      rawPayload.alerts ||
-      rawPayload.status ||
-      rawPayload.orgId ||
-      rawPayload.receiver
-    ) {
-      return "grafana";
-    }
-
-    // Check for CloudWatch SNS message structure
-    if (rawPayload.Type === "Notification" && rawPayload.Message) {
-      try {
-        const message = JSON.parse(rawPayload.Message);
-        if (message.AlarmName && message.NewStateValue) {
-          return "cloudwatch";
-        }
-      } catch {
-        // If Message parsing fails, continue with other checks
-      }
-    }
-
-    // Check for direct CloudWatch alarm structure
-    if (rawPayload.AlarmName && rawPayload.NewStateValue) {
-      return "cloudwatch";
-    }
-
-    // If we can't determine the source, fail fast
-    throw new Error("Unable to determine alert source from payload structure");
   }
 }

--- a/lambdas/collector/src/transformers/index.ts
+++ b/lambdas/collector/src/transformers/index.ts
@@ -41,7 +41,7 @@ export function detectAlertSource(sqsRecord: SQSRecord): string {
       body.state &&
       body.title &&
       body.priority &&
-      body.team
+      body.teams
     ) {
       return "normalized";
     }

--- a/lambdas/external-alerts-webhook/src/index.ts
+++ b/lambdas/external-alerts-webhook/src/index.ts
@@ -88,6 +88,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         ? event.body
         : JSON.stringify(event.body ?? {});
 
+    // This webhook also receives non grafana alerts, but we tag everything as
+    // 'grafana' for now. The code that detects the source in the collector
+    // lambda doesn't currently look at this attribute.
     await sns.send(
       new PublishCommand({
         TopicArn: TOPIC_ARN,


### PR DESCRIPTION
Previously `detectSourceFromPayload` would only return `grafana` or `cloudwatch`, but there's another function called `detectAlertSource` that gets called later that is basically the same but also able to return `normalized`, so I remove the first one and just rely on the second.

Also fix a few team vs teams thing for the normalized format

Also left a few commends about some things I spotted, mostly related to non functional things

Testing:
Added a header to the secret for some testing
Ran `make aws-apply-dev` to deploy to dev env
Used the header added to the secret in order to send a normalized alert to the external-alerts-webhook, which eventually gets to the collector lambda, saw in aws logs that it would create issues/comments