### PR TITLE
Add probot.yml to auto-tag issues with labels

### DIFF
--- a/.github/pytorch-probot.yml
+++ b/.github/pytorch-probot.yml
@@ -1,0 +1,1 @@
+tracking_issue: 1915


### PR DESCRIPTION
Relates to https://github.com/pytorch/alerting-infra/issues/1915

This PR is intended to resolve an outstanding request from ROCm CI team to tag specific members when issues related to ROCm CI infra are created on this repo. Since those issues already get tagged with `Team:rocm-queue` label, I copied this yml file and the related issue from pytorch: https://github.com/pytorch/pytorch/blob/main/.github/pytorch-probot.yml and https://github.com/pytorch/pytorch/issues/24422

cc @huydhn