### PR TITLE
feat(collector): include full alert body in update comments

### DIFF
--- a/lambdas/collector/src/index.ts
+++ b/lambdas/collector/src/index.ts
@@ -20,6 +20,48 @@ const stateManager = tableName
 const githubClient = new GitHubClient(githubRepo, githubAppSecretId, 10);
 
 /**
+ * Render the alert body shared between the initial issue and update comments.
+ *
+ * Keeping a single source of truth ensures update comments carry the same
+ * context as the filing (summary, team, priority, description, links) so
+ * watchers can read trends like queue size and queue time directly from the
+ * issue thread.
+ */
+function formatAlertBody(
+  alertEvent: import("./types").AlertEvent,
+  fingerprint: string,
+): string {
+  return [
+    alertEvent.summary ? `**${alertEvent.summary}**\n\n` : "",
+    `**Alert Details**\n`,
+    `- *Occurred At*: ${formatTimestampToPST(alertEvent.occurred_at)}\n`,
+    `- *State*: ${alertEvent.state}\n`,
+    `- *Team${alertEvent.teams.length > 1 ? "s" : ""}*: ${alertEvent.teams.join(", ")}\n`,
+    `- *Priority*: ${alertEvent.priority}\n`,
+    alertEvent.description
+      ? `- *Description*: ${alertEvent.description}\n`
+      : "",
+    alertEvent.reason ? `- *Reason*: ${alertEvent.reason}\n` : "",
+    alertEvent.links?.runbook_url
+      ? `- *Runbook*: ${alertEvent.links.runbook_url}\n`
+      : "",
+    alertEvent.links?.dashboard_url
+      ? `- *Dashboard*: ${alertEvent.links.dashboard_url}\n`
+      : "",
+    alertEvent.links?.source_url
+      ? `- *View Alert*: ${alertEvent.links.source_url}\n`
+      : "",
+    alertEvent.links?.silence_url
+      ? `- *Silence Alert*: ${alertEvent.links.silence_url}\n`
+      : "",
+    `- *Source*: ${alertEvent.source}\n`,
+    `- *Fingerprint*: \`${fingerprint}\`\n`,
+  ]
+    .filter(Boolean)
+    .join("");
+}
+
+/**
  * Create a GitHub issue for an alert
  */
 async function createGitHubIssueForAlert(
@@ -28,36 +70,7 @@ async function createGitHubIssueForAlert(
 ): Promise<{ success: boolean; issueNumber?: number; error?: string }> {
   try {
     const issueTitle = `[${alertEvent.priority}] ${alertEvent.title}`;
-
-    const issueBody = [
-      // Add summary at the top if available
-      alertEvent.summary ? `**${alertEvent.summary}**\n\n` : "",
-      `**Alert Details**\n`,
-      `- *Occurred At*: ${formatTimestampToPST(alertEvent.occurred_at)}\n`,
-      `- *State*: ${alertEvent.state}\n`,
-      `- *Team${alertEvent.teams.length > 1 ? "s" : ""}*: ${alertEvent.teams.join(", ")}\n`,
-      `- *Priority*: ${alertEvent.priority}\n`,
-      alertEvent.description
-        ? `- *Description*: ${alertEvent.description}\n`
-        : "",
-      alertEvent.reason ? `- *Reason*: ${alertEvent.reason}\n` : "",
-      alertEvent.links?.runbook_url
-        ? `- *Runbook*: ${alertEvent.links.runbook_url}\n`
-        : "",
-      alertEvent.links?.dashboard_url
-        ? `- *Dashboard*: ${alertEvent.links.dashboard_url}\n`
-        : "",
-      alertEvent.links?.source_url
-        ? `- *View Alert*: ${alertEvent.links.source_url}\n`
-        : "",
-      alertEvent.links?.silence_url
-        ? `- *Silence Alert*: ${alertEvent.links.silence_url}\n`
-        : "",
-      `- *Source*: ${alertEvent.source}\n`,
-      `- *Fingerprint*: \`${fingerprint}\`\n`,
-    ]
-      .filter(Boolean)
-      .join("");
+    const issueBody = formatAlertBody(alertEvent, fingerprint);
 
     // Create labels based on priority, teams, source, and default area label
     // Note: Team names are already normalized (spaces escaped) by transformers
@@ -140,18 +153,10 @@ async function commentOnGitHubIssueForAlert(
   fingerprint: string,
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    const commentBody = [
-      `**Alert Update**`,
-      `- **State**: ${alertEvent.state}`,
-      `- **Occurred At**: ${formatTimestampToPST(alertEvent.occurred_at)}`,
-      alertEvent.reason ? `- **Reason**: ${alertEvent.reason}` : "",
-      "",
-      "The alert condition is still active.",
-      "",
-      `**Fingerprint**: \`${fingerprint}\``,
-    ]
-      .filter(Boolean)
-      .join("\n");
+    const commentBody =
+      `**Alert Update**\n\n` +
+      formatAlertBody(alertEvent, fingerprint) +
+      `\nThe alert condition is still active.\n`;
 
     const success = await githubClient.commentOnGithubIssue(
       issueNumber,


### PR DESCRIPTION
## Summary

Update comments on alert issues currently only carry `State`, `Occurred At`, and `Fingerprint`, so watchers can't see queue size / queue time trends without leaving the thread for metrics.pytorch.org.

This PR reuses the initial issue body in update comments. For queue alerts the summary line (e.g. *"Machine X has 215 jobs in queue for 1.58 hours"*) is templated by Grafana on each evaluation, so successive comments make the trend visible at a glance.

Example of current behavior: [#4800](https://github.com/pytorch/alerting-infra/issues/4800).

## Before / after

**Before**
```
**Alert Update**
- **State**: FIRING
- **Occurred At**: May 20, 12:41am PDT

The alert condition is still active.

**Fingerprint**: `e4aa05...`
```

**After**
```
**Alert Update**

**Machine linux.rocm.gpu.gfx950.1 has 215 jobs in queue for 1.58 hours**

**Alert Details**
- *Occurred At*: May 20, 12:41am PDT
- *State*: FIRING
- *Team*: rocm-queue
- *Priority*: P2
- *Description*: Machine linux.rocm.gpu.gfx950.1 has 215 jobs in queue for 1.58 hours
- *Dashboard*: https://hud.pytorch.org/metrics
- *Source*: grafana
- *Fingerprint*: `e4aa05...`

The alert condition is still active.
```

## Implementation

Extracted the existing issue-body formatting into a shared `formatAlertBody` helper and called it from both `createGitHubIssueForAlert` and `commentOnGitHubIssueForAlert`. Issue creation is byte-identical; only the comment shape changes.

Alerts without `summary`/`description`/`links` (e.g. some CloudWatch alarms) keep the existing terse form — `filter(Boolean)` drops empty entries unchanged.

## Test plan

- [x] `yarn lint && yarn test` (CI)
- [ ] Manual verification against a staging Grafana contact point

No existing test pins the comment string, so no test updates are required.
